### PR TITLE
Add 'indexof', 'startswith', 'endswith' and 'length' string operations

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,20 +7,58 @@ const dot = require('dot-object')
 
 class NoopLogic {
   constructor () {
+    // cidr
+    // Checks if an IP address is included in a CIDR
+    // Returns a boolean
     logic.add_operation('cidr', (cidr, ip) => {
       return iptool.cidr.includes(cidr, ip)
     })
-    logic.add_operation('useragent', (string) => {
+    // useragent
+    // Parses a User-Agent
+    // Returns an object
+    logic.add_operation('useragent', string => {
       return useragent.parse(string)
     })
-    logic.add_operation('qs', (string) => {
-      const url = urlparse(string, null, (str) => {
-        if (str.startsWith('?')) str = str.substr(1)
+    // qs
+    // Parses querystring in URL/path
+    // Returns an object
+    logic.add_operation('qs', string => {
+      const url = urlparse(string, null, str => {
+        if (str[0] === '?') str = str.substr(1)
         return qs.parse(str)
       })
       if (!url || !url.query) return {}
       return url.query
     })
+    // index_of
+    // Finds index of 'a' in 'b'. Matches Javascript's indexOf behavior
+    // Returns a number
+    logic.add_operation('index_of', (a, b) => {
+      if (!b || typeof b.indexOf === 'undefined') return false
+      return b.indexOf(a)
+    })
+    // starts_with
+    // Finds if'b' starts with 'a'
+    // Returns a boolean
+    logic.add_operation('starts_with', (a, b) => {
+      if (!b || typeof b.indexOf === 'undefined') return false
+      return b.indexOf(a) === 0
+    })
+    // ends_with
+    // Finds if 'b' ends with 'a'
+    // Returns a boolean
+    logic.add_operation('ends_with', (a, b) => {
+      if (!b || typeof b.indexOf === 'undefined') return false
+      return b.substr(b.length - a.length) === a
+    })
+    // length
+    // Finds length of a string
+    // Returns a number
+    logic.add_operation('length', string => {
+      return string.length
+    })
+    // prop
+    // Reference property of resulting object from another operation
     logic.add_operation('prop', (prop, obj) => {
       if (!prop) return obj
       return dot.pick(prop, obj)

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ class NoopLogic {
       return b.indexOf(a)
     })
     // startswith
-    // Finds if'b' starts with 'a'
+    // Finds if 'b' starts with 'a'
     // Returns a boolean
     logic.add_operation('startswith', (a, b) => {
       if (!b || typeof b.indexOf === 'undefined') return false


### PR DESCRIPTION
Additional string operations to assist in creating more complex conditionals in Noop Logic.

**indexof**:
`{ "indexof": [ "bar", "foobar" ] } // 3`
`{ "indexof": [ "foobar", "bar" ] } // -1`

**startswith**:
`{ "startswith": [ "foo", "foobar" ] } // true`
`{ "startswith": [ "bar", "foobar" ] } // false`

**endswith**:
`{ "endswith": [ "foo", "foobar" ] } // false`
`{ "endswith": [ "bar", "foobar" ] } // true`

**length**:
`{ "length": [ "foobar" ] } // 6`
`{ "length": [ "" ] } // 0`