### PR TITLE
NPM Dependencies Fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,9 +29,9 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "dot-object": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/dot-object/-/dot-object-2.1.3.tgz",
-      "integrity": "sha512-YihsbZiGU2nEXQs1vjwjBNDJ85BMRHO4ahybAsuHERCxUecFoyt4xM3NO4GskNj8hFLRsgrwE4xBDe8XSOAiYg==",
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/dot-object/-/dot-object-2.1.4.tgz",
+      "integrity": "sha512-7FXnyyCLFawNYJ+NhkqyP9Wd2yzuo+7n9pGiYpkmXCTYa8Ci2U0eUNDVg5OuO5Pm6aFXI2SWN8/N/w7SJWu1WA==",
       "requires": {
         "commander": "^4.0.0",
         "glob": "^7.1.5"

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,6 +114,11 @@
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
+    "qs": {
+      "version": "6.9.6",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.9.6.tgz",
+      "integrity": "sha512-TIRk4aqYLNoJUbd+g2lEdz5kLWIuTMRagAXxl78Q0RiVjAOugHmeKNGdd3cwo/ktpf9aL9epCfFqWDEKysUlLQ=="
+    },
     "querystringify": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
@@ -159,11 +164,6 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
-    },
-    "yamlparser": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/yamlparser/-/yamlparser-0.0.2.tgz",
-      "integrity": "sha1-Mjk+avxwyMoGa2ZQrGc4tIFnjrw="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/noop-cloud/noop-logic#readme",
   "devDependencies": {},
   "dependencies": {
-    "dot-object": "^2.1.3",
+    "dot-object": "^2.1.4",
     "node-cidr": "^1.0.0",
     "qs": "^6.9.6",
     "url-parse": "^1.4.7",

--- a/package.json
+++ b/package.json
@@ -20,8 +20,8 @@
   "dependencies": {
     "dot-object": "^2.1.3",
     "node-cidr": "^1.0.0",
+    "qs": "^6.9.6",
     "url-parse": "^1.4.7",
-    "useragent": "^2.3.0",
-    "yamlparser": "0.0.2"
+    "useragent": "^2.3.0"
   }
 }


### PR DESCRIPTION
Was testing Noop Logic locally outside of any Noop services, and experienced an error due to the lack of `qs` in the project's `package.json`.

Changes:
- Added `qs` as a dependency
- Removed `yamlparser` since the project is not using it currently
- General `npm update` for project